### PR TITLE
refactor: default export LibMySql

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@
  * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
-export {
-    createTable, get, put, deleteKey, getFromNonIndex, deleteTable, createIndexForJsonField, getFromIndex, update,
-    init, close, DATA_TYPES
-} from './utils/db.js';
+import DB from './utils/db.js';
+
+const LibMySql = DB;
+
+export default LibMySql;

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -901,3 +901,21 @@ export function update(tableName, documentId, document) {
         }
     });
 }
+
+// public APIs.
+const DB = {
+    createTable,
+    get,
+    put,
+    deleteKey,
+    getFromNonIndex,
+    deleteTable,
+    createIndexForJsonField,
+    getFromIndex,
+    update,
+    init,
+    close,
+    DATA_TYPES
+};
+
+export default DB;

--- a/test/integration/libmysql-test.spec.js
+++ b/test/integration/libmysql-test.spec.js
@@ -16,15 +16,19 @@
 
 import * as chai from 'chai';
 import {getMySqlConfigs} from './setupIntegTest.js';
-import {
-    createIndexForJsonField,
-    createTable,
-    deleteKey,
-    deleteTable, getFromIndex,
-    get,
-    getFromNonIndex,
-    put, update, DATA_TYPES
-} from "../../src/index.js";
+import LibMySql from "../../src/index.js";
+
+const createIndexForJsonField = LibMySql.createIndexForJsonField;
+const createTable = LibMySql.createTable;
+const deleteKey = LibMySql.deleteKey;
+const deleteTable = LibMySql.deleteTable;
+const getFromIndex = LibMySql.getFromIndex;
+const get = LibMySql.get;
+const getFromNonIndex = LibMySql.getFromNonIndex;
+const put = LibMySql.put;
+const update = LibMySql.update;
+const DATA_TYPES = LibMySql.DATA_TYPES;
+
 import {init, close} from "../../src/utils/db.js";
 import {isObjectEmpty} from "@aicore/libcommonutils";
 import * as crypto from "crypto";

--- a/test/unit/index-test.spec.js
+++ b/test/unit/index-test.spec.js
@@ -1,6 +1,6 @@
 /*global describe, it, before*/
 import * as chai from 'chai';
-import {createTable} from "../../src/index.js";
+import LibMySql from "../../src/index.js";
 import {init} from "../../src/utils/db.js";
 import {getMySqlConfigs} from "@aicore/libcommonutils";
 
@@ -12,7 +12,7 @@ describe('testing src/index.js', function () {
     });
 
     it('createTable should pass', async function () {
-        const result = await createTable('customers', 'id', 'customer_data');
+        const result = await LibMySql.createTable('customers', 'id', 'customer_data');
         expect(result).to.eql(true);
     });
 });


### PR DESCRIPTION
`@aicore/libcommonutils` also seems to not use default object exports.

```js
import {isObject, isObjectEmpty, isString} from "@aicore/libcommonutils";
```