### PR TITLE
fix: security issue and variable name format checks

### DIFF
--- a/docs/generatedApiDocs/utils/db-API.md
+++ b/docs/generatedApiDocs/utils/db-API.md
@@ -83,17 +83,6 @@ It checks if the nameSpace is a valid table name
 
 Returns **[boolean][3]** A boolean value.
 
-## \_isValidJsonField
-
-It checks if the field is a string and if it's length is less than or equal to 63 characters and if it matches the
-regular expression `/^[a-zA-Z0-9_]+$/`
-
-### Parameters
-
-*   `field` **[String][1]** The field name to be validated.
-
-Returns **[boolean][3]** A boolean value.
-
 ## \_isValidPrimaryKey
 
 Returns true if the given key is a string of length greater than zero and less than or equal to the maximum size of a
@@ -364,16 +353,6 @@ It creates an index on the JSON field in the table
 
 Returns **void** NB `private function exporting this for testing`
 
-## \_isJsonField
-
-It checks if the jsonField is a valid json field.
-
-### Parameters
-
-*   `jsonField` **[string][1]** The JSON field to be queried.
-
-Returns **[boolean][3]** if its valid json field false otherwise
-
 ## createIndexForJsonField
 
 It creates a new column in the table for the JSON field and then creates an index on that column.
@@ -382,7 +361,8 @@ It creates a new column in the table for the JSON field and then creates an inde
 ### Parameters
 
 *   `tableName` **[string][1]** The name of the table in which you want to create the index.
-*   `jsonField` **[string][1]** The name of the field in the JSON object that you want to index.
+*   `jsonField` **[string][1]** The name of the field in the JSON object that you want to index. The filed name
+    should be a valid variable name of the form "x" or "x.y.z".
 *   `dataTypeOfNewColumn` **[string][1]** This is the data type of the new column that will be created.
     visit [https://dev.mysql.com/doc/refman/8.0/en/data-types.html][6] to know all supported data types
 *   `isUnique` **[boolean][3]** If true, the json filed has to be unique for creating index. (optional, default `false`)

--- a/src/utils/sharedUtils.js
+++ b/src/utils/sharedUtils.js
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import {isString} from "@aicore/libcommonutils";
 
 const VARIABLE_REGEX = /^[a-zA-Z_]\w*$/; // vars of form aA4_f allowed
 
@@ -36,8 +37,28 @@ export function isAlphaChar(char) {
  * Checks if the supplied name is like a variable name that starts with an alphabet or _ followed by alphanumeric/_
  * Eg. _x, x_Y, XY8, etc. are valid variable names, but a.x, 8_x, #x etc are not valid variable names.
  * @param {string} nameToTest
- * @return {boolean}
+ * @return {boolean} true if it's a valid variable name
  */
 export function isVariableNameLike(nameToTest){
     return VARIABLE_REGEX.test(nameToTest);
+}
+
+/**
+ * Similar to isVariableNameLike, but also allows nested variable of the form `var._name.like8` along with
+ * simple `varNames`.
+ * @param {string} nameToTest
+ * @returns {boolean} true if it's a valid variable name or nested variable name
+ */
+export function isNestedVariableNameLike(nameToTest) {
+    if (!isString(nameToTest)) {
+        return false;
+    }
+    const split = nameToTest.split('.');
+
+    for (let key of split) {
+        if (!isVariableNameLike(key)) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/test/unit/utils/db-security-test.spec.js
+++ b/test/unit/utils/db-security-test.spec.js
@@ -1,0 +1,37 @@
+import mockedFunctions from '../setup-mocks.js';
+import * as chai from 'chai';
+import {
+    init,
+    close,
+    getFromNonIndex
+} from "../../../src/utils/db.js";
+import {getMySqlConfigs} from "@aicore/libcommonutils";
+
+let expect = chai.expect;
+
+describe('Unit tests for db.js', function () {
+    beforeEach(function () {
+        close();
+        init(getMySqlConfigs());
+    });
+
+    it('getFromNonIndex key sql injection attack test', async function () {
+        const saveExecute = mockedFunctions.connection.execute;
+        mockedFunctions.connection.execute = function (sql, values, callback) {
+            callback(null, [], []);
+        };
+        const tableName = 'test.hello';
+        let isExceptionOccurred = false;
+        try {
+            await getFromNonIndex(tableName, {
+                "yo\"= \"x\" OR 1 != (SELECT COUNT(*) FROM test.arun) OR not \"1": "x"
+            });
+        } catch (e) {
+            expect(e.split('\n')[0]).to.eql('Exception occurred while getting data Error:' +
+                ` Invalid filed name yo"= "x" OR 1 != (SELECT COUNT(*) FROM test.arun) OR not "1`);
+            isExceptionOccurred = true;
+        }
+        expect(isExceptionOccurred).to.eql(true);
+        mockedFunctions.connection.execute = saveExecute;
+    });
+});

--- a/test/unit/utils/sharedUtils-test.spec.js
+++ b/test/unit/utils/sharedUtils-test.spec.js
@@ -1,6 +1,7 @@
 /*global describe, it*/
 import mockedFunctions from '../setup-mocks.js';
-import {isAlphaNumChar, isAlphaChar, isVariableNameLike} from "../../../src/utils/sharedUtils.js";
+import {isAlphaNumChar, isAlphaChar, isVariableNameLike,
+    isNestedVariableNameLike} from "../../../src/utils/sharedUtils.js";
 import chai from "chai";
 let expect = chai.expect;
 
@@ -22,17 +23,38 @@ describe('Shared Utils test', function () {
         expect(isAlphaNumChar('_')).to.be.false;
     });
 
-    it('should isVariableNameLike work', function () {
-        expect(isVariableNameLike('aA8_')).to.be.true;
-        expect(isVariableNameLike('_')).to.be.true;
-        expect(isVariableNameLike('HELLO_WORLD_9_')).to.be.true;
-        expect(isVariableNameLike('camelCase8')).to.be.true;
+    function _validateVarNames(validatorFn) {
+        expect(validatorFn('aA8_')).to.be.true;
+        expect(validatorFn('_')).to.be.true;
+        expect(validatorFn('HELLO_WORLD_9_')).to.be.true;
+        expect(validatorFn('camelCase8')).to.be.true;
 
-        expect(isVariableNameLike('8')).to.be.false;
-        expect(isVariableNameLike('8asc')).to.be.false;
-        expect(isVariableNameLike('8asc#')).to.be.false;
-        expect(isVariableNameLike('#')).to.be.false;
-        expect(isVariableNameLike('.ads')).to.be.false;
+        expect(validatorFn('8')).to.be.false;
+        expect(validatorFn('8asc')).to.be.false;
+        expect(validatorFn('8asc#')).to.be.false;
+        expect(validatorFn('#')).to.be.false;
+        expect(validatorFn('.ads')).to.be.false;
+    }
+
+    it('should isVariableNameLike work', function () {
+        _validateVarNames(isVariableNameLike);
         expect(isVariableNameLike('s.ads')).to.be.false;
+    });
+
+    it('should isNestedVariableNameLike work', function () {
+        _validateVarNames(isNestedVariableNameLike);
+        expect(isNestedVariableNameLike('aA8_.aA8_')).to.be.true;
+        expect(isNestedVariableNameLike('_._')).to.be.true;
+        expect(isNestedVariableNameLike('HELLO_.WORLD._9._')).to.be.true;
+        expect(isNestedVariableNameLike('camelCase8.camelCase8')).to.be.true;
+
+        expect(isNestedVariableNameLike('8')).to.be.false;
+        expect(isNestedVariableNameLike('8asc')).to.be.false;
+        expect(isNestedVariableNameLike('8asc#')).to.be.false;
+        expect(isNestedVariableNameLike('#')).to.be.false;
+        expect(isNestedVariableNameLike('.ads')).to.be.false;
+        expect(isNestedVariableNameLike('ads.')).to.be.false;
+        expect(isNestedVariableNameLike('HELLO_.WORLD. _9._')).to.be.false;
+        expect(isNestedVariableNameLike('HELLO_.WORLD.._')).to.be.false;
     });
 });


### PR DESCRIPTION
## Fix security issue with SQL injection attack in `getFromNonIndex` API.
Earlier, `getFromNonIndex` query could be tricked to execute random SQL queries(See Eg. below). Fixed
```js
{
  "tableName": "test.arun",
  "queryObject": {
    "yo\"= \"☺\" OR 1 != (SELECT COUNT(*) FROM test.arun) OR not \"1": "☺"
  }
}
```

## Other Fixes
* Variable names should now adhere to format `/^[a-zA-Z_]\w*$/;`.  Eg. vars of form `aA4_f` allowed
* `getFromNonIndex` now only accepts query fields of format `varName` or  `var_name.x.y` etc. and not any generic json strrings.
* removed old `_isValidJsonField` method as the query length limitation doesn't exist within scan fields.