### PR TITLE
chore: cocdb to mysql query transformation and tests

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,22 @@
+/* Declaring a constant variable named MAX_NUMBER_OF_DOCS_ALLOWED and assigning it the value of 1000. */
+export const MAX_NUMBER_OF_DOCS_ALLOWED = 1000;
+/* Defining a constant variable called PRIMARY_COLUMN and assigning it the value of 'documentID'. */
+export const PRIMARY_COLUMN = 'documentID';
+/* Defining a constant variable called JSON_COLUMN and assigning it the value of 'document'. */
+export const JSON_COLUMN = 'document';
+/* Creating a constant called DATA_TYPES. It is an object with three properties. The first property is DOUBLE, which is
+ a string. The second property is VARCHAR, which is a function that takes a parameter. The third property is INT,
+ which is a string. */
+export const DATA_TYPES = {
+    // https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html
+    DOUBLE: 'DOUBLE',
+    VARCHAR: function (a = 50) {
+        return `VARCHAR(${a})`;
+    },
+    INT: 'INT'
+};
+// https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
+/* Defining a constant variable named MAXIMUM_LENGTH_OF_MYSQL_TABLE_NAME_AND_COLUMN_NAME and
+assigning it the value 64. */
+export const MAXIMUM_LENGTH_OF_MYSQL_TABLE_NAME_AND_COLUMN_NAME = 63;
+export const MAXIMUM_LENGTH_OF_MYSQL_DATABASE_NAME = 63;

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -3,33 +3,13 @@ import {isObject, isObjectEmpty, isString} from "@aicore/libcommonutils";
 import crypto from "crypto";
 import {isNumber} from "@aicore/libcommonutils/src/utils/common.js";
 import {getColumNameForJsonField, isVariableNameLike, isNestedVariableNameLike} from "./sharedUtils.js";
+import {JSON_COLUMN, MAX_NUMBER_OF_DOCS_ALLOWED, PRIMARY_COLUMN, DATA_TYPES,
+    MAXIMUM_LENGTH_OF_MYSQL_TABLE_NAME_AND_COLUMN_NAME, MAXIMUM_LENGTH_OF_MYSQL_DATABASE_NAME} from './constants.js';
 
 // @INCLUDE_IN_API_DOCS
 
 let CONNECTION = null;
 
-/* Declaring a constant variable named MAX_NUMBER_OF_DOCS_ALLOWED and assigning it the value of 1000. */
-const MAX_NUMBER_OF_DOCS_ALLOWED = 1000;
-/* Defining a constant variable called PRIMARY_COLUMN and assigning it the value of 'documentID'. */
-export const PRIMARY_COLUMN = 'documentID';
-/* Defining a constant variable called JSON_COLUMN and assigning it the value of 'document'. */
-export const JSON_COLUMN = 'document';
-/* Creating a constant called DATA_TYPES. It is an object with three properties. The first property is DOUBLE, which is
- a string. The second property is VARCHAR, which is a function that takes a parameter. The third property is INT,
- which is a string. */
-export const DATA_TYPES = {
-    // https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html
-    DOUBLE: 'DOUBLE',
-    VARCHAR: function (a = 50) {
-        return `VARCHAR(${a})`;
-    },
-    INT: 'INT'
-};
-// https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
-/* Defining a constant variable named MAXIMUM_LENGTH_OF_MYSQL_TABLE_NAME_AND_COLUMN_NAME and
-assigning it the value 64. */
-const MAXIMUM_LENGTH_OF_MYSQL_TABLE_NAME_AND_COLUMN_NAME = 63;
-const MAXIMUM_LENGTH_OF_MYSQL_DATABASE_NAME = 63;
 /* Defining a constant variable called SIZE_OF_PRIMARY_KEY and assigning it the value of 32. */
 const SIZE_OF_PRIMARY_KEY = 32;
 

--- a/test/unit/setup-mocks.js
+++ b/test/unit/setup-mocks.js
@@ -16,7 +16,7 @@ let mockedFunctions = {
                 }
             }, undefined);
         },
-        close : function (){}
+        close: function (){}
     }
 };
 

--- a/test/unit/utils/db-test.spec.js
+++ b/test/unit/utils/db-test.spec.js
@@ -13,13 +13,15 @@ import {
     createIndexForJsonField,
     _createIndex,
     getFromIndex,
-    JSON_COLUMN,
     update,
-    DATA_TYPES,
     createDataBase,
     deleteDataBase,
     mathAdd
 } from "../../../src/utils/db.js";
+import {
+    JSON_COLUMN,
+    DATA_TYPES
+} from "../../../src/utils/constants.js";
 import {getMySqlConfigs} from "@aicore/libcommonutils";
 
 let expect = chai.expect;


### PR DESCRIPTION
# transformCocoToSQLQuery(query, useIndexForFields = [])
Transforms CocoDB queries to MYSql queries. Coco queries closely resemble the mysql query syntax. The json field
names can be directly specified in coco queries.
A Sample coco query:
`NOT(customerID = 35 && (price.tax < 18 OR ROUND(price.amount) != 69))`

## `$` is a special character that denotes the JSON document itself.
It can be used for json compare as. `JSON_CONTAINS($,'{"name": "v"}')`.
** WARNING: JSON_CONTAINS this will not use the index. We may add support in future, but not presently. **

## cocodb query syntax
cocodb query syntax closely resembles mysql query syntax. The following functions are supported as is:

### Supported functions
#### MATH functions defined in https://dev.mysql.com/doc/refman/8.0/en/mathematical-functions.html
    'ABS', 'ACOS', 'ASIN', 'ATAN', 'ATAN2', 'ATAN', 'CEIL', 'CEILING', 'CONV', 'COS', 'COT',
    'CRC32', 'DEGREES', 'EXP', 'FLOOR', 'LN', 'LOG', 'LOG10', 'LOG2', 'MOD', 'PI', 'POW', 'POWER', 'RADIANS', 'RAND',
    'ROUND', 'SIGN', 'SIN', 'SQRT', 'TAN', 'TRUNCATE',
#### String functions defined in https://dev.mysql.com/doc/refman/8.0/en/string-functions.html
    "ASCII", "BIN", "BIT_LENGTH", "CHAR", "CHAR_LENGTH", "CHARACTER_LENGTH", "CONCAT", "CONCAT_WS", "ELT", "EXPORT_SET",
    "FIELD", "FORMAT", "FROM_BASE64", "HEX", "INSERT", "INSTR", "LCASE", "LEFT", "LENGTH", "LOAD_FILE", "LOCATE",
    "LOWER", "LPAD", "LTRIM", "MAKE_SET", "MATCH", "MID", "OCT", "OCTET_LENGTH", "ORD", "POSITION", "QUOTE",
    "REGEXP_INSTR", "REGEXP_LIKE", "REGEXP_REPLACE", "REGEXP_SUBSTR", "REPEAT", "REPLACE", "REVERSE", "RIGHT",
    "RPAD", "RTRIM", "SOUNDEX", "SPACE", "SUBSTR", "SUBSTRING", "SUBSTRING_INDEX", "TO_BASE64", "TRIM",
    "UCASE", "UNHEX", "UPPER", "WEIGHT_STRING",
#### comparison
    "SOUNDS", "STRCMP",
#### Selected APIs defined in https://dev.mysql.com/doc/refman/8.0/en/flow-control-functions.html
    "IF", "IFNULL", "NULLIF", "IN",
#### Selected JSON Functions in https://dev.mysql.com/doc/refman/8.0/en/json-function-reference.html
    "JSON_CONTAINS", "JSON_CONTAINS_PATH", "JSON_KEYS", "JSON_DEPTH", "JSON_LENGTH", "JSON_REMOVE", "JSON_REPLACE",
    "JSON_INSERT", "JSON_MERGE_PATCH", "JSON_MERGE_PRESERVE", "JSON_OVERLAPS", "JSON_SEARCH", "JSON_SET", "JSON_TYPE",
    "JSON_VALID", "JSON_VALUE", "MEMBEROF"
#### Other Keywords
    "LIKE", "NOT", "REGEXP", "RLIKE", "NULL", "AND", "OR", "IS", "BETWEEN", "XOR"

@param {string} query The query as string.
@param {Array<String>} useIndexForFields A string array of field names for which the index should be used. Note
that an index should first be created using `createIndexForJsonField` API. Eg. ['customerID', 'price.tax']
@return {string} The MYSQL query string corresponding to the cocdb query.