### PR TITLE
change query syntax to include $. for json fields

### DIFF
--- a/docs/generatedApiDocs/utils/db-API.md
+++ b/docs/generatedApiDocs/utils/db-API.md
@@ -545,7 +545,7 @@ A Sample coco query
 
 ```javascript
 const tableName = 'customer';
-const queryString = `NOT(customerID = 35 && (price.tax < 18 OR ROUND(price.amount) != 69))`;
+const queryString = `NOT($.customerID = 35 && ($.price.tax < 18 OR ROUND($.price.amount) != 69))`;
 try {
      const queryResults = await query(tableName, queryString, ["customerID"]); // customerID is indexed field
      console.log(JSON.stringify(queryResults));
@@ -556,7 +556,9 @@ try {
 ## cocodb query syntax
 cocodb query syntax closely resembles mysql query syntax. The following functions are supported as is:
 
-### `$` is a special character that denotes the JSON document itself in queries.
+## `$` is a special character that denotes the JSON document itself.
+All json field names should be prefixed with a `$.` symbol. For Eg. field `x.y` should be given
+in query as `$.x.y`.
 It can be used for json compare as. `JSON_CONTAINS($,'{"name": "v"}')`.
 ** WARNING: JSON_CONTAINS this will not use the index. We may add support in future, but not presently. **
 

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1077,7 +1077,7 @@ function _executeQuery(sqlQuery, resolve, reject) {
  * fields to search on the index instead of scanning the whole table.
  * @example <caption> A Sample coco query </caption>
  * const tableName = 'customer';
- * const queryString = `NOT(customerID = 35 && (price.tax < 18 OR ROUND(price.amount) != 69))`;
+ * const queryString = `NOT($.customerID = 35 && ($.price.tax < 18 OR ROUND($.price.amount) != 69))`;
  * try {
  *      const queryResults = await query(tableName, queryString, ["customerID"]); // customerID is indexed field
  *      console.log(JSON.stringify(queryResults));
@@ -1088,7 +1088,9 @@ function _executeQuery(sqlQuery, resolve, reject) {
  * ## cocodb query syntax
  * cocodb query syntax closely resembles mysql query syntax. The following functions are supported as is:
  *
- * ### `$` is a special character that denotes the JSON document itself in queries.
+ * ## `$` is a special character that denotes the JSON document itself.
+ * All json field names should be prefixed with a `$.` symbol. For Eg. field `x.y` should be given
+ * in query as `$.x.y`.
  * It can be used for json compare as. `JSON_CONTAINS($,'{"name": "v"}')`.
  * ** WARNING: JSON_CONTAINS this will not use the index. We may add support in future, but not presently. **
  *

--- a/test/integration/libmysql-test.spec.js
+++ b/test/integration/libmysql-test.spec.js
@@ -485,7 +485,7 @@ describe('Integration: libMySql', function () {
     });
     it('basic query test should pass', async function () {
         const docId = await put(tableName, {age: 10, total: 100});
-        const results = await query(tableName, 'age = 10');
+        const results = await query(tableName, '$.age = 10');
         expect(results[0].documentId).eql(docId);
         expect(results[0].age).eql(10);
         expect(results[0].total).eql(100);
@@ -500,7 +500,7 @@ describe('Integration: libMySql', function () {
                 'state': 'Karnataka'
             }
         });
-        const results = await query(tableName, "location.city  = 'Banglore'");
+        const results = await query(tableName, "$.location.city  = 'Banglore'");
         expect(results[0].documentId).eql(docId);
         expect(results[0].Age).eql(100);
         expect(results[0].location.state).eql('Karnataka');
@@ -520,7 +520,7 @@ describe('Integration: libMySql', function () {
                 'state': 'Karnataka'
             }
         });
-        const results = await query(tableName, "location.city  = 'Banglore' AND location.state = 'Karnataka'", ['location.city']);
+        const results = await query(tableName, "$.location.city  = 'Banglore' AND $.location.state = 'Karnataka'", ['location.city']);
         expect(results[0].documentId).eql(docId);
         expect(results[0].Age).eql(100);
         expect(results[0].location.state).eql('Karnataka');


### PR DESCRIPTION
- feat: change query syntax to include $. for json fields
- fix: integration tests

```js
const tableName = 'customer';
const queryString = `NOT($.customerID = 35 && ($.price.tax < 18 OR ROUND($.price.amount) != 69))`;
try {
     const queryResults = await query(tableName, queryString, ["customerID"]); // customerID is indexed field
     console.log(JSON.stringify(queryResults));
} catch (e) {
     console.error(JSON.stringify(e));
}
```