### PR TITLE
feat: deleteDocuments api and unit tests

### DIFF
--- a/docs/generatedApiDocs/utils/db-API.md
+++ b/docs/generatedApiDocs/utils/db-API.md
@@ -167,6 +167,32 @@ try {
 Returns **[Promise][2]** A promise `resolve` promise to get status of delete. promise will resolve to true
 for success and  throws an exception for failure.
 
+## deleteDocuments
+
+Deletes a document from the database based the given query condition and returns the number of documents deleted.
+
+### Parameters
+
+*   `tableName` **[string][1]** The name of the table in which the key is to be deleted.
+*   `queryString` **[string][1]** The cocDB query string.
+*   `useIndexForFields`   (optional, default `[]`)
+
+### Examples
+
+Sample code
+
+```javascript
+const tableName = 'dbName:customers';
+try {
+   // delete all documents with field 'location.city' set to paris
+   let deletedDocumentCount = await deleteDocuments(tableName, "$.location.city  = 'paris'", ['location.city']);
+} catch(e) {
+   console.error(e);
+}
+```
+
+Returns **[Promise][2]** A promise `resolve` with the number of deleted documents or throws an exception for failure.
+
 ## get
 
 It takes in a table name and documentId, and returns a promise that resolves to the document

--- a/test/integration/libmysql-test.spec.js
+++ b/test/integration/libmysql-test.spec.js
@@ -669,6 +669,24 @@ describe('Integration: libMySql', function () {
         deletedDocCount = await deleteDocuments(tableName, "$.counter  = 10");
         expect(deletedDocCount).eql(0);
     });
+    it('deleteDocuments without index field should delete multiple document', async function () {
+        await populateTestTable(100);
+        let results = await query(tableName, "$.counter  >= 10 AND $.counter  <= 27");
+        expect(results.length).eql(18);
+
+        let deletedDocCount = await deleteDocuments(tableName, "$.counter  >= 10 AND $.counter  <= 27");
+        expect(deletedDocCount).eql(18);
+        results = await query(tableName, "$.counter  >= 10 AND $.counter  <= 27");
+        expect(results.length).eql(0);
+
+        // deleting again should delete no documents as there are none
+        deletedDocCount = await deleteDocuments(tableName, "$.counter  >= 10 AND $.counter  <= 27");
+        expect(deletedDocCount).eql(0);
+
+        // count remaining documents to verify nothing else gets deleted
+        results = await query(tableName, "$.Age  = 100"); // all has age 100
+        expect(results.length).eql(82);
+    });
     it('deleteDocuments with index field should delete single document', async function () {
         const createIndexStatus = await createIndexForJsonField(tableName, 'counter', DATA_TYPES.VARCHAR(), false, true);
         expect(createIndexStatus).eql(true);
@@ -685,6 +703,26 @@ describe('Integration: libMySql', function () {
         // deleting again should delete no documents as there are none
         deletedDocCount = await deleteDocuments(tableName, "$.counter  = 10", ['counter']);
         expect(deletedDocCount).eql(0);
+    });
+    it('deleteDocuments with index field should delete multiple document', async function () {
+        const createIndexStatus = await createIndexForJsonField(tableName, 'counter', DATA_TYPES.VARCHAR(), false, true);
+        expect(createIndexStatus).eql(true);
+        await populateTestTable(100);
+        let results = await query(tableName, "$.counter  >= 10 AND $.counter  <= 27", ['counter']);
+        expect(results.length).eql(18);
+
+        let deletedDocCount = await deleteDocuments(tableName, "$.counter  >= 10 AND $.counter  <= 27", ['counter']);
+        expect(deletedDocCount).eql(18);
+        results = await query(tableName, "$.counter  >= 10 AND $.counter  <= 27", ['counter']);
+        expect(results.length).eql(0);
+
+        // deleting again should delete no documents as there are none
+        deletedDocCount = await deleteDocuments(tableName, "$.counter  >= 10 AND $.counter  <= 27", ['counter']);
+        expect(deletedDocCount).eql(0);
+
+        // count remaining documents to verify nothing else gets deleted
+        results = await query(tableName, "$.Age  = 100"); // all has age 100
+        expect(results.length).eql(82);
     });
 });
 


### PR DESCRIPTION
## deleteDocuments
Deletes a document from the database based the given query condition and returns the number of documents deleted.
### Parameters
*   `tableName` **[string][1]** The name of the table in which the key is to be deleted.
*   `queryString` **[string][1]** The cocDB query string.
*   `useIndexForFields`   (optional, default `[]`)
### Examples
Sample code
```javascript
const tableName = 'dbName:customers';
try {
   // delete all documents with field 'location.city' set to paris
   let deletedDocumentCount = await deleteDocuments(tableName, "$.location.city  = 'paris'", ['location.city']);
} catch(e) {
   console.error(e);
}
```
Returns **[Promise][2]** A promise `resolve` with the number of deleted documents or throws an exception for failure.

part of https://github.com/aicore/libmysql/issues/159